### PR TITLE
Updated Swedish time rules

### DIFF
--- a/resources/languages/sv/rules/time.clj
+++ b/resources/languages/sv/rules/time.clj
@@ -486,7 +486,7 @@
     (merge {:precision "exact"}))
 
   "about <time-of-day>" ; about
-  [#"(?i)(omkring|cirka|runt|ca\.)( kl\.| klockan)?" {:form :time-of-day}]
+  [#"(?i)(omkring|cirka|vid|runt|ca\.)( kl\.| klockan)?" {:form :time-of-day}]
   (-> %2
     (dissoc :latent)
     (merge {:precision "approximate"}))


### PR DESCRIPTION
Fixed the rules a bit by adding `vid` (to allow for `imorgon vid 12` => `tomorrow by 12`).