### PR TITLE
[EN] More natural disambiguation of intervals

### DIFF
--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -656,6 +656,14 @@
   "9:30 - 11:00"
   (datetime-interval [2013 2 12 9 30] [2013 2 12 11 1])
 
+  "between 7 and 8 PM"
+  "between 7 PM and 8 PM"
+  (datetime-interval [2013 2 12 19] [2013 2 12 21])
+
+  "from 7 to 8 PM"
+  "from 7 PM to 8 PM"
+  (datetime-interval [2013 2 12 19] [2013 2 12 21])
+
   "from 9:30 - 11:00 on Thursday"
   "between 9:30 and 11:00 on thursday"
   "9:30 - 11:00 on Thursday"

--- a/resources/languages/en/rules/time.clj
+++ b/resources/languages/en/rules/time.clj
@@ -604,17 +604,9 @@
   [#"(?i)between" {:form :time-of-day} #"and" {:form :time-of-day}]
   (interval %2 %4 true)
 
-  "between <time-of-day-latent> and <time-of-day-latent> (interval) am|pm"
-  [#"(?i)between" #(and (= :time-of-day (:form %)) (:latent %)) #"and" #(and (= :time-of-day (:form %)) (:latent %)) #"(?i)([ap])\.?m?\.?"]
-  (let [[p meridiem] (if (= "a" (-> %5 :groups first clojure.string/lower-case))
-                       [[(hour 0) (hour 12) false] :am]
-                       [[(hour 12) (hour 0) false] :pm])]
-    (interval
-      (-> (intersect %2 (apply interval p))
-        (assoc :form :time-of-day))
-      (-> (intersect %4 (apply interval p))
-        (assoc :form :time-of-day))
-      true))
+  "between <time-of-day-latent> and <time-of-day-ampm> (interval)"
+  [#"(?i)between" #(and (= :time-of-day (:form %)) (:latent %)) #"and" #(and (= :time-of-day (:form %)) (:ampm %))]
+  (interval (pred-nth-after %2 %4 -1) %4 true)
 
   ; Specific for within duration... Would need to be reworked
   "within <duration>"

--- a/resources/languages/en/rules/time.clj
+++ b/resources/languages/en/rules/time.clj
@@ -617,6 +617,10 @@
         (assoc :form :time-of-day))
       true))
 
+  "between <time-of-day> and <time-of-day> (interval)"
+  [#"(?i)between" {:form :time-of-day} #"and" {:form :time-of-day}]
+  (interval %2 %4 true)
+
   "between <time-of-day-latent> and <time-of-day-latent> (interval) am|pm"
   [#"(?i)between" #(and (= :time-of-day (:form %)) (:latent %)) #"and" #(and (= :time-of-day (:form %)) (:latent %)) #"(?i)([ap])\.?m?\.?"]
   (let [[p meridiem] (if (= "a" (-> %5 :groups first clojure.string/lower-case))

--- a/resources/languages/en/rules/time.clj
+++ b/resources/languages/en/rules/time.clj
@@ -377,24 +377,15 @@
   ;                  (Integer/parseInt (second (:groups %1)))
   ;                  false) ; not a 12-hour clock)
   ;     (assoc :latent true))
-  (let [[p meridiem] (if (= "a" (-> %2 :groups first clojure.string/lower-case))
-                       [[(hour 0) (hour 12) false] :am]
-                       [[(hour 12) (hour 0) false] :pm])]
-    (-> (intersect
-          (hour-minute (Integer/parseInt (first (:groups %1)))
-                       (Integer/parseInt (second (:groups %1)))
-                   true)
-          (apply interval p))
-        (assoc :form :time-of-day)))
+  (set-meridiem
+        (hour-minute (Integer/parseInt (first (:groups %1)))
+                     (Integer/parseInt (second (:groups %1)))
+                 true)
+        (-> %2 :groups first clojure.string/lower-case))
 
   "<time-of-day> am|pm"
   [{:form :time-of-day} #"(?i)(in the )?([ap])(\s|\.)?m?\.?"]
-  ;; TODO set_am fn in helpers => add :ampm field
-  (let [[p meridiem] (if (= "a" (-> %2 :groups second clojure.string/lower-case))
-                       [[(hour 0) (hour 12) false] :am]
-                       [[(hour 12) (hour 0) false] :pm])]
-    (-> (intersect %1 (apply interval p))
-        (assoc :form :time-of-day)))
+  (set-meridiem %1 (-> %2 :groups second clojure.string/lower-case))
 
   "noon"
   #"(?i)noon"
@@ -605,17 +596,9 @@
   [#"(?i)(later than|from)" {:form :time-of-day} #"((but )?before)|\-|to|th?ru|through|(un)?til(l)?" {:form :time-of-day}]
   (interval %2 %4 true)
 
-  "from <time-of-day-latent> - <time-of-day-latent> (interval) am|pm"
-  [#"(?i)(later than|from)" #(and (= :time-of-day (:form %)) (:latent %)) #"\-|:|to|th?ru|through|(un)?til(l)?" #(and (= :time-of-day (:form %)) (:latent %)) #"(?i)([ap])\.?m?\.?"]
-  (let [[p meridiem] (if (= "a" (-> %5 :groups first clojure.string/lower-case))
-                       [[(hour 0) (hour 12) false] :am]
-                       [[(hour 12) (hour 0) false] :pm])]
-    (interval
-      (-> (intersect %2 (apply interval p))
-        (assoc :form :time-of-day))
-      (-> (intersect %4 (apply interval p))
-        (assoc :form :time-of-day))
-      true))
+  "from <time-of-day-latent> - <time-of-day-ampm> (interval)"
+  [#"(?i)(later than|from)" #(and (= :time-of-day (:form %)) (:latent %)) #"\-|:|to|th?ru|through|(un)?til(l)?" #(and (= :time-of-day (:form %)) (:ampm %))]
+  (interval (pred-nth-after %2 %4 -1) %4 true)
 
   "between <time-of-day> and <time-of-day> (interval)"
   [#"(?i)between" {:form :time-of-day} #"and" {:form :time-of-day}]

--- a/src/duckling/time/prod.clj
+++ b/src/duckling/time/prod.clj
@@ -118,6 +118,13 @@
     (hour-minute (if (pos? m) h (case (int h) 0 23 1 12 (dec h))) (mod m 60) true)
     (hour-minute (if (pos? m) h (case (int h) 0 23 1 0 (dec h))) (mod m 60) false)))
 
+; helper for dealing with am|pm
+(defn set-meridiem [tod ampm-first-letter]
+  (let [[p meridiem] (if (= "a" ampm-first-letter)
+                       [[(hour 0) (hour 12) false] :am]
+                       [[(hour 12) (hour 0) false] :pm])]
+    (-> (intersect tod (apply interval p))
+        (assoc :form :time-of-day :ampm meridiem))))
 
 (defn cycle-nth [grain n]
   (ti (p/take-the-nth (p/cycle grain) n)))


### PR DESCRIPTION
This commit adds two new rules to "better" handle ambiguous time intervals
suffixed with an AM or PM. Typically, "from 7 to 8 PM" and "between 7 and 8 PM"
refer to the interval from 1900 to 2000, and _not_ the interval 0700 to 2000.

This behavior has been a bit annoying to end users of our application. I recognize this
change represents an opinionated design decision, but I do think my proposed semantics
are more mainstream.